### PR TITLE
Add Mediator to alice/faber demo

### DIFF
--- a/aries_cloudagent/protocols/coordinate_mediation/v1_0/tests/test_mediation_manager.py
+++ b/aries_cloudagent/protocols/coordinate_mediation/v1_0/tests/test_mediation_manager.py
@@ -2,7 +2,7 @@ from asynctest import TestCase as AsyncTestCase
 from asynctest import mock as async_mock
 
 from aries_cloudagent.config.injection_context import InjectionContext
-from aries_cloudagent.connections.models.connection_record import ConnectionRecord
+from aries_cloudagent.connections.models.conn_record import ConnRecord
 from aries_cloudagent.messaging.request_context import RequestContext
 from aries_cloudagent.storage.base import BaseStorage
 from aries_cloudagent.storage.basic import BasicStorage
@@ -31,7 +31,7 @@ class TestMediationManager(AsyncTestCase):
             base_context=InjectionContext(enforce_typing=False)
         )
         self.context.message_receipt = MessageReceipt(sender_verkey=TEST_VERKEY)
-        self.context.connection_record = ConnectionRecord(connection_id=TEST_CONN_ID)
+        self.context.connection_record = ConnRecord(connection_id=TEST_CONN_ID)
         self.storage = BasicStorage()
         self.wallet = BasicWallet()
         self.context.injector.bind_instance(BaseStorage, self.storage)

--- a/demo/runners/alice.py
+++ b/demo/runners/alice.py
@@ -249,7 +249,7 @@ async def main(
         log_msg("Endpoint URL is at:", agent.endpoint)
 
         if mediation:
-            mediator_agent = await start_mediator_agent(start_port+4, genesis)
+            mediator_agent = await start_mediator_agent(start_port+4, genesis, agent)
         else:
             mediator_agent = None
 

--- a/demo/runners/faber.py
+++ b/demo/runners/faber.py
@@ -210,7 +210,10 @@ async def main(
             log_status(
                 "#7 Create a connection to alice and print out the invite details"
             )
-            connection = await agent.admin_POST("/connections/create-invitation")
+            if mediation:
+                connection = await agent.admin_POST("/mediation/requests/client/" + agent.mediator_request_id + "/generate-invitation")
+            else:
+                connection = await agent.admin_POST("/connections/create-invitation")
 
         agent.connection_id = connection["connection_id"]
 

--- a/demo/runners/faber.py
+++ b/demo/runners/faber.py
@@ -177,7 +177,7 @@ async def main(
         log_msg("Endpoint URL is at:", agent.endpoint)
 
         if mediation:
-            mediator_agent = await start_mediator_agent(start_port+4, genesis)
+            mediator_agent = await start_mediator_agent(start_port+4, genesis, agent)
         else:
             mediator_agent = None
 


### PR DESCRIPTION
Add a "--mediation" option to alice/faber to run a mediator agent and auto-mediate connections.

Starts mediator and connects mediator to (alice or faber).  Faber uses mediator request to generate invitation for alice.

Opening a PR for visibility
